### PR TITLE
Bump mgw version to 3.2.5 and upgrade Alpine base image and JRE to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Docker resources for WSO2 API Microgateway will be docume
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v3.2.5.1] - 2022-08-08
+
+### Changed
+
+- Upgrade to API Microgateway 3.2.5 (refer to [issue](https://github.com/wso2/docker-mg/issues/27))
+- Upgrade Alpine Base Image and JRE to latest (refer to [issue](https://github.com/wso2/docker-mg/issues/28))
+
 ## [v3.2.4.2] - 2022-06-13
 
 ### Changed
@@ -52,3 +59,4 @@ For detailed information on the tasks carried out during this release, please se
 [v3.2.1.2]: https://github.com/wso2/docker-mg/compare/v3.2.1.1...v3.2.1.2
 [v3.2.3.1]: https://github.com/wso2/docker-mg/compare/v3.2.1.2...v3.2.3.1
 [v3.2.4.2]: https://github.com/wso2/docker-mg/compare/v3.2.3.1...v3.2.4.2
+[v3.2.5.1]: https://github.com/wso2/docker-mg/compare/v3.2.4.2...v3.2.5.1

--- a/dockerfiles/alpine/mg/Dockerfile
+++ b/dockerfiles/alpine/mg/Dockerfile
@@ -14,10 +14,10 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
-FROM alpine:3.16.0
+FROM alpine:3.16.1
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-mg/releases/tag/v3.2.4.2"
+      com.wso2.docker.source="https://github.com/wso2/docker-mg/releases/tag/v3.2.5.1"
 
 ENV LANG=C.UTF-8
 
@@ -27,13 +27,13 @@ ARG USER_ID=802
 ARG USER_GROUP=ballerina
 ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
-ARG JRE_BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jre_x64_linux_hotspot_8u332b09.tar.gz'
+ARG JRE_BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jre_x64_linux_hotspot_8u345b01.tar.gz'
 ARG INTERNAL_JRE=jdk8u332-b09-jre
 ARG JRE_HOME=/opt/java/openjdk
 
 # build arguments for WSO2 product installation
 ARG MGW_SERVER_NAME=wso2am-micro-gw-linux
-ARG MGW_SERVER_VERSION=3.2.4
+ARG MGW_SERVER_VERSION=3.2.5
 ARG MGW_SERVER=${MGW_SERVER_NAME}-${MGW_SERVER_VERSION}
 ARG MGW_RUNTIME_HOME=${USER_HOME}/wso2
 ARG MGW_SERVER_DIST_URL=https://github.com/wso2/product-microgateway/releases/download/v${MGW_SERVER_VERSION}/${MGW_SERVER}.zip

--- a/dockerfiles/alpine/mg/README.md
+++ b/dockerfiles/alpine/mg/README.md
@@ -11,7 +11,7 @@ This section defines the step-by-step instructions to build an [Alpine](https://
 1. Navigate to `/dockerfiles/alpine/mg` directory.
 2. Build the Docker image using the following command.
 
-```docker build --no-cache=true -t wso2/wso2micro-gw:3.2.4 .```
+```docker build --no-cache=true -t wso2/wso2micro-gw:3.2.5 .```
    
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
 

--- a/dockerfiles/ubuntu/mg/Dockerfile
+++ b/dockerfiles/ubuntu/mg/Dockerfile
@@ -17,7 +17,7 @@
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
 FROM ubuntu:20.04
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-mg/releases/tag/v3.2.4.2"
+      com.wso2.docker.source="https://github.com/wso2/docker-mg/releases/tag/v3.2.5.1"
 
 ENV LANG=C.UTF-8
 
@@ -28,13 +28,13 @@ ARG USER_ID=802
 ARG USER_GROUP=ballerina
 ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
-ARG JRE_BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jre_x64_linux_hotspot_8u332b09.tar.gz'
+ARG JRE_BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jre_x64_linux_hotspot_8u345b01.tar.gz'
 ARG INTERNAL_JRE=jdk8u332-b09-jre
 ARG JRE_HOME=/opt/java/openjdk
 
 # build arguments for WSO2 product installation
 ARG MGW_SERVER_NAME=wso2am-micro-gw-linux
-ARG MGW_SERVER_VERSION=3.2.4
+ARG MGW_SERVER_VERSION=3.2.5
 ARG MGW_SERVER=${MGW_SERVER_NAME}-${MGW_SERVER_VERSION}
 ARG MGW_RUNTIME_HOME=${USER_HOME}/wso2
 ARG MGW_SERVER_DIST_URL=https://github.com/wso2/product-microgateway/releases/download/v${MGW_SERVER_VERSION}/${MGW_SERVER}.zip

--- a/dockerfiles/ubuntu/mg/README.md
+++ b/dockerfiles/ubuntu/mg/README.md
@@ -11,7 +11,7 @@ This section defines the step-by-step instructions to build an [Ubuntu](https://
 1. Navigate to `/dockerfiles/ubuntu/mg` directory.
 2. Build the Docker image using the following command.
 
-```docker build --no-cache=true -t wso2/wso2micro-gw:3.2.4-ubuntu .```
+```docker build --no-cache=true -t wso2/wso2micro-gw:3.2.5-ubuntu .```
    
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
 


### PR DESCRIPTION
### Purpose
- Bump mgw version to **3.2.5**
- Upgrade Alpine base image to latest
- Upgrade JRE to latest

### Issues
- Resolves https://github.com/wso2/docker-mg/issues/27
- Resolves https://github.com/wso2/docker-mg/issues/28
