### PR TITLE
Upgrade JDK version to 17

### DIFF
--- a/dockerfiles/alpine/mg/Dockerfile
+++ b/dockerfiles/alpine/mg/Dockerfile
@@ -27,7 +27,7 @@ ARG USER_ID=802
 ARG USER_GROUP=ballerina
 ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
-ARG JRE_BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jre_x64_linux_hotspot_8u382b05.tar.gz'
+ARG JRE_BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.11_9.tar.gz'
 ARG INTERNAL_JRE=jdk8u382-b05-jre
 ARG JRE_HOME=/opt/java/openjdk
 

--- a/dockerfiles/ubuntu/mg/Dockerfile
+++ b/dockerfiles/ubuntu/mg/Dockerfile
@@ -28,7 +28,7 @@ ARG USER_ID=802
 ARG USER_GROUP=ballerina
 ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
-ARG JRE_BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jre_x64_linux_hotspot_8u382b05.tar.gz'
+ARG JRE_BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.11_9.tar.gz'
 ARG INTERNAL_JRE=jdk8u382-b05-jre
 ARG JRE_HOME=/opt/java/openjdk
 


### PR DESCRIPTION
This PR is for upgrading the JDK version in Ubuntu and Alpine Docker images.

### Tested environments
OS : Ubuntu 22.04.4 LTS
Docker version: 27.1.1, build 6312585

