### PR TITLE
Upgrade Alpine base image to 3.19.4 and Ubuntu base image to 24.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Docker resources for WSO2 API Microgateway will be docume
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [v3.2.9.4] - 2024-08-30
+
+### Changed
+- Upgrade Alpine base image to 3.19.4 and Ubuntu base image to 24.04 (refer to [issue](https://github.com/wso2/docker-mg/issues/56))
+
 ## [v3.2.9.3] - 2024-07-29
 
 ### Changed
@@ -98,3 +103,4 @@ For detailed information on the tasks carried out during this release, please se
 [v3.2.8.1]: https://github.com/wso2/docker-mg/compare/v3.2.7.1...v3.2.8.1
 [v3.2.8.2]: https://github.com/wso2/docker-mg/compare/v3.2.8.1...v3.2.8.2
 [v3.2.9.3]: https://github.com/wso2/docker-mg/compare/v3.2.9.2...v3.2.9.3
+[v3.2.9.4]: https://github.com/wso2/docker-mg/compare/v3.2.9.3...v3.2.9.4

--- a/dockerfiles/alpine/mg/Dockerfile
+++ b/dockerfiles/alpine/mg/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
-FROM alpine:3.19.1
+FROM alpine:3.19.4
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-mg/releases/tag/v3.2.9.3"

--- a/dockerfiles/alpine/mg/Dockerfile
+++ b/dockerfiles/alpine/mg/Dockerfile
@@ -17,7 +17,7 @@
 FROM alpine:3.19.4
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-mg/releases/tag/v3.2.9.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-mg/releases/tag/v3.2.9.4"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/dockerfiles/alpine/mg/README.md
+++ b/dockerfiles/alpine/mg/README.md
@@ -11,7 +11,7 @@ This section defines the step-by-step instructions to build an [Alpine](https://
 1. Navigate to `/dockerfiles/alpine/mg` directory.
 2. Build the Docker image using the following command.
 
-```docker build --no-cache=true -t wso2/wso2micro-gw:3.2.9.3 .```
+```docker build --no-cache=true -t wso2/wso2micro-gw:3.2.9.4 .```
    
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
 

--- a/dockerfiles/ubuntu/mg/Dockerfile
+++ b/dockerfiles/ubuntu/mg/Dockerfile
@@ -17,7 +17,7 @@
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
 FROM ubuntu:24.04
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-mg/releases/tag/v3.2.9.3"
+      com.wso2.docker.source="https://github.com/wso2/docker-mg/releases/tag/v3.2.9.4"
 
 ENV LANG=C.UTF-8
 

--- a/dockerfiles/ubuntu/mg/Dockerfile
+++ b/dockerfiles/ubuntu/mg/Dockerfile
@@ -15,7 +15,7 @@
 # -----------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-mg/releases/tag/v3.2.9.3"
 
@@ -63,7 +63,7 @@ RUN \
         fontconfig \
         locales \
         libxml2-utils \
-        netcat \
+        netcat-traditional \
         unzip \
         wget \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \

--- a/dockerfiles/ubuntu/mg/README.md
+++ b/dockerfiles/ubuntu/mg/README.md
@@ -11,7 +11,7 @@ This section defines the step-by-step instructions to build an [Ubuntu](https://
 1. Navigate to `/dockerfiles/ubuntu/mg` directory.
 2. Build the Docker image using the following command.
 
-```docker build --no-cache=true -t wso2/wso2micro-gw:3.2.9.3-ubuntu .```
+```docker build --no-cache=true -t wso2/wso2micro-gw:3.2.9.4-ubuntu .```
    
 > By default, the Docker image will prepackage the General Availability (GA) release version of the relevant WSO2 product.
 


### PR DESCRIPTION
### Purpose
This PR upgrades Alpine base image to 3.19.4 and Ubuntu base image to 24.04.

### Issues
Fixes https://github.com/wso2/docker-mg/issues/56
